### PR TITLE
Don't hard-code prefix for the global installation.

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,15 +4,36 @@ import shutil
 # Script to install the generator.
 # Copied from https://github.com/romainberger/yeoman-wordpress/
 
-generatorPath = '/usr/local/lib/node_modules/yeoman/node_modules/yeoman-generators/lib/generators'
-currentDir = os.path.dirname(os.path.abspath(__file__))
-bootstrapLessPath = os.path.join(generatorPath, 'bootstrap-less')
+def which(program):
+    import os
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+yeomanBinaryPath = yeomanInstalled = which('yeoman')
 
 # Check if Yeoman is installed
-if not os.path.isdir(generatorPath):
+if not yeomanInstalled:
     print 'It seems that Yeoman is not installed.'
     print 'If you have trouble installing the generator please refer to the install instructions in the Readme.'
     os.exit()
+
+yeomanPrefix = os.path.normpath(os.path.join(yeomanBinaryPath, '../../'))
+generatorPath = os.path.join(yeomanPrefix, 'lib/node_modules/yeoman/node_modules/yeoman-generators/lib/generators')
+currentDir = os.path.dirname(os.path.abspath(__file__))
+bootstrapLessPath = os.path.join(generatorPath, 'bootstrap-less')
 
 # if the generator is already installed we remove it to avoid errors
 if os.path.isdir(bootstrapLessPath):


### PR DESCRIPTION
This uses a more reliable way to determine whether `yeoman` is installed
or not and allows for `yeoman-bootstrap-less` to work with `yeoman`
installs under the /usr prefix (or any other, for that matter).
