### PR TITLE
Inherit from Base instead of NamedBase

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -27,7 +27,7 @@ var BootstrapLessGenerator = module.exports = function BootstrapLessGenerator(ar
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
 };
 
-util.inherits(BootstrapLessGenerator, yeoman.generators.NamedBase);
+util.inherits(BootstrapLessGenerator, yeoman.generators.Base);
 
 BootstrapLessGenerator.prototype.askFor = function askFor() {
   var cb = this.async();


### PR DESCRIPTION
With the next release of `yeoman-generator`, NamedBase will raise an exception if a generator is called without an argument.
