### PR TITLE
Updating yeoman-generator to 0.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.3"
+    "yeoman-generator": "~0.13.4"
   },
   "peerDependencies": {
     "generator-mocha": "~0.1.1"


### PR DESCRIPTION
Ran into problems with a clean install of yeoman and this generator. Got "cannot read property 'bold' of undefined" and found out that this is due to changes in yeoman and common to other generators. This fixes that.
