### PR TITLE
correcting the glyphicons path on Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -254,7 +254,7 @@ module.exports = function (grunt) {
         }, {
           expand: true,
           dot: true,
-          cwd: '<%%= yeoman.app %>/bower_components/bootstrap/fonts/',
+          cwd: '<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/',
           dest: '<%%= yeoman.app %>/fonts/glyphicons',
           src: ['*']
         }]


### PR DESCRIPTION
Hey, Thomas!

I was having some problems to use the glyphicons from bootstrap. After a long time I noticed that Grunt creates a folder named dist where the fonts are loaded, so I changed on Gruntfile.js and worked perfectly.

Don't know if it happened to other people, but if it does, I hope it helps.

Great job with the generator, it has been very helpfull! 
