### PR TITLE
Upgrade to LESS v2, minor .htaccess comment fix

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-htmlmin": "~0.3.0",
-    "grunt-contrib-less": "~0.11.4",
+    "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-imagemin": "0.8.1",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.8.0",<% } %>
     "grunt-contrib-watch": "~0.6.1",

--- a/app/templates/htaccess
+++ b/app/templates/htaccess
@@ -154,7 +154,8 @@ AddType text/x-vcard                        vcf
 
 <IfModule mod_deflate.c>
 
-  # Force deflate for mangled headers developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
+  # Force deflate for mangled headers.
+  # developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
   <IfModule mod_setenvif.c>
     <IfModule mod_headers.c>
       SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding


### PR DESCRIPTION
Upgrade to grunt-contrib-less v1.0.x - includes LESS v2, which supports major enhancements like plug-ins etc. Plus fix a broken URL in an .htaccess comment 